### PR TITLE
replace embedded-time with fugit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ no-std-net = { version = "^0.5", features = ["serde"] }
 embedded-nal = "0.6.0"
 nb = "^1"
 #atat = { version = "0.13.1", features = ["derive"] }
-atat = { git = "https://github.com/andresv/atat.git", branch = "use-fugit-for-timing", features = ["derive"] }
+atat = { git = "https://github.com/BlackbirdHQ/atat.git", features = ["derive"] }
 hash32 = "0.2.1"
 hash32-derive = "^0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ heapless = { version = "^0.7", features = ["serde"] }
 no-std-net = { version = "^0.5", features = ["serde"] }
 embedded-nal = "0.6.0"
 nb = "^1"
-atat = { version = "0.13.1", features = ["derive"] }
+#atat = { version = "0.13.1", features = ["derive"] }
+atat = { git = "https://github.com/andresv/atat.git", branch = "use-fugit-for-timing", features = ["derive"] }
 hash32 = "0.2.1"
 hash32-derive = "^0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fugit = "0.2.1"
+fugit = "0.3"
 defmt = "0.2"
 serde = { version = "^1", default-features = false, features = ["derive"] }
 heapless = { version = "^0.7", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-time = "0.11.0"
+fugit = "0.2.1"
 defmt = "0.2"
 serde = { version = "^1", default-features = false, features = ["derive"] }
 heapless = { version = "^0.7", features = ["serde"] }
@@ -16,6 +16,9 @@ nb = "^1"
 atat = { version = "0.13.1", features = ["derive"] }
 hash32 = "0.2.1"
 hash32-derive = "^0.1.0"
+
+[dev-dependencies]
+embedded-hal = { version = "=1.0.0-alpha.4" }
 
 [features]
 default = ["socket-udp", "socket-tcp"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,8 @@ pub mod tcp;
 pub mod tcp_listener;
 pub mod udp;
 
-use core::convert::TryInto;
-
 pub(crate) use self::meta::Meta as SocketMeta;
 pub use self::ring_buffer::RingBuffer;
-use embedded_time::{
-    duration::{Generic, Milliseconds},
-    Clock, Instant,
-};
 
 #[cfg(feature = "socket-tcp")]
 pub use tcp::{State as TcpState, TcpSocket};
@@ -54,6 +48,7 @@ pub enum Error {
 }
 
 type Result<T> = core::result::Result<T, Error>;
+pub type Instant<const FREQ_HZ: u32> = fugit::TimerInstantU32<FREQ_HZ>;
 
 /// A network socket.
 ///
@@ -66,11 +61,11 @@ type Result<T> = core::result::Result<T, Error>;
 /// [AnySocket]: trait.AnySocket.html
 /// [SocketSet::get]: struct.SocketSet.html#method.get
 #[non_exhaustive]
-pub enum Socket<CLK: Clock, const L: usize> {
+pub enum Socket<const FREQ_HZ: u32, const L: usize> {
     #[cfg(feature = "socket-udp")]
-    Udp(UdpSocket<CLK, L>),
+    Udp(UdpSocket<FREQ_HZ, L>),
     #[cfg(feature = "socket-tcp")]
-    Tcp(TcpSocket<CLK, L>),
+    Tcp(TcpSocket<FREQ_HZ, L>),
 }
 
 #[non_exhaustive]
@@ -80,7 +75,7 @@ pub enum SocketType {
     Tcp,
 }
 
-impl<CLK: Clock, const L: usize> Socket<CLK, L> {
+impl<const FREQ_HZ: u32, const L: usize> Socket<FREQ_HZ, L> {
     /// Return the socket handle.
     #[inline]
     pub fn handle(&self) -> SocketHandle {
@@ -103,10 +98,7 @@ impl<CLK: Clock, const L: usize> Socket<CLK, L> {
         }
     }
 
-    pub fn should_update_available_data(&mut self, ts: Instant<CLK>) -> bool
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn should_update_available_data(&mut self, ts: Instant<FREQ_HZ>) -> bool {
         match self {
             Socket::Tcp(s) => s.should_update_available_data(ts),
             Socket::Udp(s) => s.should_update_available_data(ts),
@@ -120,20 +112,14 @@ impl<CLK: Clock, const L: usize> Socket<CLK, L> {
         }
     }
 
-    pub fn recycle(&self, ts: &Instant<CLK>) -> bool
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn recycle(&self, ts: Instant<FREQ_HZ>) -> bool {
         match self {
             Socket::Tcp(s) => s.recycle(ts),
             Socket::Udp(s) => s.recycle(ts),
         }
     }
 
-    pub fn closed_by_remote(&mut self, ts: Instant<CLK>)
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn closed_by_remote(&mut self, ts: Instant<FREQ_HZ>) {
         match self {
             Socket::Tcp(s) => s.closed_by_remote(ts),
             Socket::Udp(s) => s.closed_by_remote(ts),
@@ -170,13 +156,13 @@ impl<CLK: Clock, const L: usize> Socket<CLK, L> {
 }
 
 /// A conversion trait for network sockets.
-pub trait AnySocket<CLK: Clock, const L: usize>: Sized {
-    fn downcast(socket_ref: SocketRef<'_, Socket<CLK, L>>) -> Result<SocketRef<'_, Self>>;
+pub trait AnySocket<const FREQ_HZ: u32, const L: usize>: Sized {
+    fn downcast(socket_ref: SocketRef<'_, Socket<FREQ_HZ, L>>) -> Result<SocketRef<'_, Self>>;
 }
 
 #[cfg(feature = "socket-tcp")]
-impl<CLK: Clock, const L: usize> AnySocket<CLK, L> for TcpSocket<CLK, L> {
-    fn downcast(ref_: SocketRef<'_, Socket<CLK, L>>) -> Result<SocketRef<'_, Self>> {
+impl<const FREQ_HZ: u32, const L: usize> AnySocket<FREQ_HZ, L> for TcpSocket<FREQ_HZ, L> {
+    fn downcast(ref_: SocketRef<'_, Socket<FREQ_HZ, L>>) -> Result<SocketRef<'_, Self>> {
         match SocketRef::into_inner(ref_) {
             Socket::Tcp(ref mut socket) => Ok(SocketRef::new(socket)),
             _ => Err(Error::Illegal),
@@ -185,8 +171,8 @@ impl<CLK: Clock, const L: usize> AnySocket<CLK, L> for TcpSocket<CLK, L> {
 }
 
 #[cfg(feature = "socket-udp")]
-impl<CLK: Clock, const L: usize> AnySocket<CLK, L> for UdpSocket<CLK, L> {
-    fn downcast(ref_: SocketRef<'_, Socket<CLK, L>>) -> Result<SocketRef<'_, Self>> {
+impl<const FREQ_HZ: u32, const L: usize> AnySocket<FREQ_HZ, L> for UdpSocket<FREQ_HZ, L> {
+    fn downcast(ref_: SocketRef<'_, Socket<FREQ_HZ, L>>) -> Result<SocketRef<'_, Self>> {
         match SocketRef::into_inner(ref_) {
             Socket::Udp(ref mut socket) => Ok(SocketRef::new(socket)),
             _ => Err(Error::Illegal),

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,24 +1,22 @@
-use core::convert::TryInto;
+use super::{Error, Instant, Result, RingBuffer, Socket, SocketHandle, SocketMeta};
 use embedded_nal::SocketAddr;
-use embedded_time::{duration::*, Clock, Instant};
-
-use super::{Error, Result, RingBuffer, Socket, SocketHandle, SocketMeta};
+use fugit::{ExtU32, SecsDurationU32};
 
 /// A TCP socket ring buffer.
 pub type SocketBuffer<const N: usize> = RingBuffer<u8, N>;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum State<CLK: Clock> {
+pub enum State<const FREQ_HZ: u32> {
     /// Freshly created, unsullied
     Created,
     WaitingForConnect(SocketAddr),
     /// TCP connected or UDP has an address
     Connected(SocketAddr),
     /// Block all writes (Socket is closed by remote)
-    ShutdownForWrite(Instant<CLK>),
+    ShutdownForWrite(Instant<FREQ_HZ>),
 }
 
-impl<CLK: Clock> defmt::Format for State<CLK> {
+impl<const FREQ_HZ: u32> defmt::Format for State<FREQ_HZ> {
     fn format(&self, fmt: defmt::Formatter) {
         match self {
             State::Created => defmt::write!(fmt, "State::Created"),
@@ -29,7 +27,7 @@ impl<CLK: Clock> defmt::Format for State<CLK> {
     }
 }
 
-impl<CLK: Clock> Default for State<CLK> {
+impl<const FREQ_HZ: u32> Default for State<FREQ_HZ> {
     fn default() -> Self {
         State::Created
     }
@@ -41,19 +39,19 @@ impl<CLK: Clock> Default for State<CLK> {
 /// Note that, for listening sockets, there is no "backlog"; to be able to simultaneously
 /// accept several connections, as many sockets must be allocated, or any new connection
 /// attempts will be reset.
-pub struct TcpSocket<CLK: Clock, const L: usize> {
+pub struct TcpSocket<const FREQ_HZ: u32, const L: usize> {
     pub(crate) meta: SocketMeta,
-    state: State<CLK>,
-    check_interval: Seconds<u32>,
-    read_timeout: Option<Seconds<u32>>,
+    state: State<FREQ_HZ>,
+    check_interval: SecsDurationU32,
+    read_timeout: Option<SecsDurationU32>,
     available_data: usize,
     rx_buffer: SocketBuffer<L>,
-    last_check_time: Option<Instant<CLK>>,
+    last_check_time: Option<Instant<FREQ_HZ>>,
 }
 
-impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
+impl<const FREQ_HZ: u32, const L: usize> TcpSocket<FREQ_HZ, L> {
     /// Create a socket using the given buffers.
-    pub fn new(socket_id: u8) -> TcpSocket<CLK, L> {
+    pub fn new(socket_id: u8) -> TcpSocket<FREQ_HZ, L> {
         TcpSocket {
             meta: SocketMeta {
                 handle: SocketHandle(socket_id),
@@ -61,8 +59,8 @@ impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
             state: State::default(),
             rx_buffer: SocketBuffer::new(),
             available_data: 0,
-            check_interval: Seconds(15),
-            read_timeout: Some(Seconds(15)),
+            check_interval: 15.secs(),
+            read_timeout: Some(15.secs()),
             last_check_time: None,
         }
     }
@@ -85,14 +83,11 @@ impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
     }
 
     /// Return the connection state, in terms of the TCP state machine.
-    pub fn state(&self) -> &State<CLK> {
+    pub fn state(&self) -> &State<FREQ_HZ> {
         &self.state
     }
 
-    pub fn should_update_available_data(&mut self, ts: Instant<CLK>) -> bool
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn should_update_available_data(&mut self, ts: Instant<FREQ_HZ>) -> bool {
         // Cannot request available data on a socket that is closed by the
         // module
         if !self.is_connected() {
@@ -101,10 +96,8 @@ impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
 
         let should_update = self
             .last_check_time
-            .as_ref()
             .and_then(|last_check_time| ts.checked_duration_since(last_check_time))
-            .and_then(|dur| dur.try_into().ok())
-            .map(|dur: Milliseconds<u32>| dur >= self.check_interval)
+            .map(|dur| dur >= self.check_interval)
             .unwrap_or(true);
 
         if should_update {
@@ -114,17 +107,13 @@ impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
         should_update
     }
 
-    pub fn recycle(&self, ts: &Instant<CLK>) -> bool
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn recycle(&self, ts: Instant<FREQ_HZ>) -> bool {
         if let Some(read_timeout) = self.read_timeout {
             match self.state {
                 State::Created | State::WaitingForConnect(_) | State::Connected(_) => false,
-                State::ShutdownForWrite(ref closed_time) => ts
+                State::ShutdownForWrite(closed_time) => ts
                     .checked_duration_since(closed_time)
-                    .and_then(|dur| dur.try_into().ok())
-                    .map(|dur: Milliseconds<u32>| dur >= read_timeout)
+                    .map(|dur| dur >= read_timeout)
                     .unwrap_or(false),
             }
         } else {
@@ -132,10 +121,7 @@ impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
         }
     }
 
-    pub fn closed_by_remote(&mut self, ts: Instant<CLK>)
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn closed_by_remote(&mut self, ts: Instant<FREQ_HZ>) {
         self.set_state(State::ShutdownForWrite(ts));
         self.set_available_data(0);
     }
@@ -287,13 +273,13 @@ impl<CLK: Clock, const L: usize> TcpSocket<CLK, L> {
         self.rx_buffer.len()
     }
 
-    pub fn set_state(&mut self, state: State<CLK>) {
+    pub fn set_state(&mut self, state: State<FREQ_HZ>) {
         self.state = state
     }
 }
 
-impl<CLK: Clock, const L: usize> Into<Socket<CLK, L>> for TcpSocket<CLK, L> {
-    fn into(self) -> Socket<CLK, L> {
+impl<const FREQ_HZ: u32, const L: usize> Into<Socket<FREQ_HZ, L>> for TcpSocket<FREQ_HZ, L> {
+    fn into(self) -> Socket<FREQ_HZ, L> {
         Socket::Tcp(self)
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -283,7 +283,12 @@ impl<const TIMER_HZ: u32, const L: usize> TcpSocket<TIMER_HZ, L> {
     }
 
     pub fn set_state(&mut self, state: State<TIMER_HZ>) {
-        defmt::debug!("[{:?}] TCP state change: {:?} -> {:?}", self.handle(), self.state, state);
+        defmt::debug!(
+            "[{:?}] TCP state change: {:?} -> {:?}",
+            self.handle(),
+            self.state,
+            state
+        );
         self.state = state
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,9 +1,7 @@
 use core::cmp::min;
-use core::convert::TryInto;
+use fugit::{ExtU32, SecsDurationU32};
 
-use embedded_time::{duration::*, Clock, Instant};
-
-use super::{Error, Result, RingBuffer, Socket, SocketHandle, SocketMeta};
+use super::{Error, Instant, Result, RingBuffer, Socket, SocketHandle, SocketMeta};
 pub use embedded_nal::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 /// A UDP socket ring buffer.
@@ -25,28 +23,28 @@ impl Default for State {
 ///
 /// A UDP socket is bound to a specific endpoint, and owns transmit and receive
 /// packet buffers.
-pub struct UdpSocket<CLK: Clock, const L: usize> {
+pub struct UdpSocket<const FREQ_HZ: u32, const L: usize> {
     pub(crate) meta: SocketMeta,
     pub(crate) endpoint: Option<SocketAddr>,
-    check_interval: Seconds<u32>,
-    read_timeout: Option<Seconds<u32>>,
+    check_interval: SecsDurationU32,
+    read_timeout: Option<SecsDurationU32>,
     state: State,
     available_data: usize,
     rx_buffer: SocketBuffer<L>,
-    last_check_time: Option<Instant<CLK>>,
-    closed_time: Option<Instant<CLK>>,
+    last_check_time: Option<Instant<FREQ_HZ>>,
+    closed_time: Option<Instant<FREQ_HZ>>,
 }
 
-impl<CLK: Clock, const L: usize> UdpSocket<CLK, L> {
+impl<const FREQ_HZ: u32, const L: usize> UdpSocket<FREQ_HZ, L> {
     /// Create an UDP socket with the given buffers.
-    pub fn new(socket_id: u8) -> UdpSocket<CLK, L> {
+    pub fn new(socket_id: u8) -> UdpSocket<FREQ_HZ, L> {
         UdpSocket {
             meta: SocketMeta {
                 handle: SocketHandle(socket_id),
             },
-            check_interval: Seconds(15),
+            check_interval: 15.secs(),
             state: State::Closed,
-            read_timeout: Some(Seconds(15)),
+            read_timeout: Some(15.secs()),
             endpoint: None,
             available_data: 0,
             rx_buffer: SocketBuffer::new(),
@@ -78,37 +76,26 @@ impl<CLK: Clock, const L: usize> UdpSocket<CLK, L> {
         self.state = state
     }
 
-    pub fn should_update_available_data(&mut self, ts: Instant<CLK>) -> bool
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn should_update_available_data(&mut self, ts: Instant<FREQ_HZ>) -> bool {
         self.last_check_time
             .replace(ts)
-            .and_then(|ref last_check_time| ts.checked_duration_since(last_check_time))
-            .and_then(|dur| dur.try_into().ok())
-            .map(|dur: Milliseconds<u32>| dur >= self.check_interval)
+            .and_then(|last_check_time| ts.checked_duration_since(last_check_time))
+            .map(|dur| dur >= self.check_interval)
             .unwrap_or(false)
     }
 
-    pub fn recycle(&self, ts: &Instant<CLK>) -> bool
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn recycle(&self, ts: Instant<FREQ_HZ>) -> bool {
         if let Some(read_timeout) = self.read_timeout {
             self.closed_time
-                .and_then(|ref closed_time| ts.checked_duration_since(closed_time))
-                .and_then(|dur| dur.try_into().ok())
-                .map(|dur: Milliseconds<u32>| dur >= read_timeout)
+                .and_then(|closed_time| ts.checked_duration_since(closed_time))
+                .map(|dur| dur >= read_timeout)
                 .unwrap_or(false)
         } else {
             false
         }
     }
 
-    pub fn closed_by_remote(&mut self, ts: Instant<CLK>)
-    where
-        Generic<CLK::T>: TryInto<Milliseconds>,
-    {
+    pub fn closed_by_remote(&mut self, ts: Instant<FREQ_HZ>) {
         self.closed_time.replace(ts);
     }
 
@@ -234,8 +221,8 @@ impl<CLK: Clock, const L: usize> UdpSocket<CLK, L> {
     }
 }
 
-impl<CLK: Clock, const L: usize> Into<Socket<CLK, L>> for UdpSocket<CLK, L> {
-    fn into(self) -> Socket<CLK, L> {
+impl<const FREQ_HZ: u32, const L: usize> Into<Socket<FREQ_HZ, L>> for UdpSocket<FREQ_HZ, L> {
+    fn into(self) -> Socket<FREQ_HZ, L> {
         Socket::Udp(self)
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -73,7 +73,12 @@ impl<const TIMER_HZ: u32, const L: usize> UdpSocket<TIMER_HZ, L> {
     }
 
     pub fn set_state(&mut self, state: State) {
-        defmt::debug!("{}, UDP state change: {:?} -> {:?}", self.handle(), self.state, state);
+        defmt::debug!(
+            "{}, UDP state change: {:?} -> {:?}",
+            self.handle(),
+            self.state,
+            state
+        );
         self.state = state
     }
 


### PR DESCRIPTION
`embedded-time` has some serious issues and moves too slowly and tries to do too much in single lib.
[fugit](https://lib.rs/crates/fugit) is a time library that was built out of frustration to `embedded-time`.
`fugit` only deals with time conversions and those conversions are done using const generics. So most of the time calculations are done during compilation. This is very light weight compared to `embedded-time` which makes it very suitable for embedded systems.

Also there are issues with some of the `embedded-time` dependencies which makes it unusable at the moment on ESP32.

Next step is to update [ublox-cellular-rs](https://github.com/BlackbirdHQ/ublox-cellular-rs) also to `fugit`. I am working on it at the moment.