### PR TITLE
fixes to build sara-r5 for ublox-cellular

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,11 @@ documentation = "https://docs.rs/ublox-sockets"
 serde = { version = "^1", default-features = false, features = ["derive"] }
 heapless = { version = "^0.7", features = ["serde"] }
 no-std-net = { version = "^0.5", features = ["serde"] }
-atat = { version = "0.19", features = ["derive"] }
+#atat = { version = "0.19", features = ["derive"] }
+atat = { git = "https://github.com/BlackbirdHQ/atat", rev = "c5caaf7", features = [
+    "derive",
+    "bytes",
+] }
 hash32 = "0.2.1"
 hash32-derive = "^0.1.0"
 embassy-time = "0.1"

--- a/src/set.rs
+++ b/src/set.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
     PartialEq,
     Eq,
     PartialOrd,
-    AtatLen,
     Ord,
     hash32_derive::Hash32,
     Default,
@@ -20,6 +19,11 @@ use serde::{Deserialize, Serialize};
 )]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Handle(pub u8);
+
+// Implement AtatLen with 1 as the ublox module only support 0-9
+impl atat::AtatLen for Handle {
+    const LEN: usize = 1;
+}
 
 /// An extensible set of sockets.
 #[derive(Default, Debug)]


### PR DESCRIPTION
Newtypes need to be implemented manually for defmt.
Did the same for AtatLen.
To be able to accept the impl in ublox-cellular match the atat version with it.